### PR TITLE
use File::Slurper

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -2,7 +2,7 @@ requires perl => '5.14.1';
 requires 'Carp';
 requires 'Digest::SHA1';
 requires 'File::Share';
-requires 'File::Slurp::Tiny';
+requires 'File::Slurper';
 requires 'JSON::MaybeXS';
 requires 'List::Util';
 requires 'Moo';

--- a/lib/Redis/RateLimit.pm
+++ b/lib/Redis/RateLimit.pm
@@ -6,7 +6,7 @@ use Moo;
 use Carp;
 use Digest::SHA1 qw/sha1_hex/;
 use File::Share qw/dist_file/;
-use File::Slurp::Tiny qw/read_file/;
+use File::Slurper qw/read_text/;
 use JSON::MaybeXS;
 use List::Util qw/any max min/;
 use Redis;
@@ -110,7 +110,7 @@ sub _read_lua {
     my ( $self, $filename ) = @_;
 
     my $path = dist_file('Redis-RateLimit', "$filename.lua");
-    read_file($path, binmode => ':utf8');
+    read_text($path);
 }
 
 sub _check_limit_script {


### PR DESCRIPTION
File::Slurper is recommended over File::Slurp::Tiny as it abandons the interface problems inherited from File::Slurp, and thus being simpler to use correctly.